### PR TITLE
[Refactoring] depth_buffer | log_depth_image | log_pinhole_depth

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2587,27 +2587,20 @@ pub fn log_mesh(
 /// log depth image data to the rerun recording stream
 /// # Arguments
 /// * `rec` - The rerun::RecordingStream instance
-/// * `depth_image` - The depth image data
-/// * `resolution` - The width and height of the depth image
-/// * `min_depth` - The minimum depth value
-/// * `max_depth` - The maximum depth value
+/// * `cam` - The Camera instance
 /// # Errors
 /// * If the data cannot be logged to the recording stream
 /// # Example
 /// ```no_run
-/// use peng_quad::log_depth_image;
+/// use peng_quad::{log_depth_image, Camera};
 /// let rec = rerun::RecordingStreamBuilder::new("log.rerun").connect().unwrap();
-/// let depth_image = vec![0.0; 640 * 480];
-/// log_depth_image(&rec, &depth_image, (640usize, 480usize), 0.0, 1.0).unwrap();
+/// let camera = Camera::new((640, 480), 0.1, 100.0, 60.0);
+/// log_depth_image(&rec, &camera).unwrap();
 /// ```
-pub fn log_depth_image(
-    rec: &rerun::RecordingStream,
-    depth_image: &[f32],
-    resolution: (usize, usize),
-    min_depth: f32,
-    max_depth: f32,
-) -> Result<(), SimulationError> {
-    let (width, height) = resolution;
+pub fn log_depth_image(rec: &rerun::RecordingStream, cam: &Camera) -> Result<(), SimulationError> {
+    let (width, height) = (cam.resolution.0, cam.resolution.1);
+    let (min_depth, max_depth) = (cam.near, cam.far);
+    let depth_image = &cam.depth_buffer;
     let mut image = rerun::external::ndarray::Array::zeros((height, width, 3));
     let depth_range = max_depth - min_depth;
     image

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2655,7 +2655,7 @@ pub fn log_depth_image(
 /// let camera = Camera::new((800, 600), 60.0, 0.1, 100.0);
 /// pinhole_depth(&rec, &camera, cam_position, cam_orientation, cam_transform, &depth_image).unwrap();
 
-pub fn pinhole_depth(
+pub fn log_pinhole_depth(
     rec: &rerun::RecordingStream,
     cam: &Camera,
     cam_position: Vector3<f32>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2633,7 +2633,6 @@ pub fn log_depth_image(rec: &rerun::RecordingStream, cam: &Camera) -> Result<(),
 /// * `cam_position` - The position vector of the camera (aligns with the quad)
 /// * `cam_orientation` - The orientation quaternion of quad
 /// * `cam_transform` - The transform matrix between quad and camera alignment
-/// * `depth_image` - The depth image data
 /// # Errors
 /// * If the data cannot be logged to the recording stream
 /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2196,12 +2196,6 @@ impl Camera {
             * Matrix3::new(1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0);
         let rotation_world_to_camera = rotation_camera_to_world.transpose();
 
-        // Pre-compute rotated ray directions
-        let rotated_rays: Vec<Vector3<f32>> = self
-            .ray_directions
-            .iter()
-            .map(|&dir| rotation_camera_to_world * dir)
-            .collect();
         const CHUNK_SIZE: usize = 64;
         if use_multi_threading {
             self.depth_buffer
@@ -2217,7 +2211,7 @@ impl Camera {
                         *depth = ray_cast(
                             quad_position,
                             &rotation_world_to_camera,
-                            &rotated_rays[ray_idx],
+                            &(rotation_camera_to_world * &self.ray_directions[ray_idx]),
                             maze,
                             self.near,
                             self.far,

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), SimulationError> {
         config.maze.obstacles_velocity_bounds,
         config.maze.obstacles_radius_bounds,
     );
-    let camera = Camera::new(
+    let mut camera = Camera::new(
         config.camera.resolution,
         config.camera.fov_vertical.to_radians(),
         config.camera.near,
@@ -60,7 +60,6 @@ fn main() -> Result<(), SimulationError> {
     );
     let mut planner_manager = PlannerManager::new(Vector3::zeros(), 0.0);
     let mut trajectory = Trajectory::new(Vector3::new(0.0, 0.0, 0.0));
-    let mut depth_buffer: Vec<f32> = vec![0.0; camera.resolution.0 * camera.resolution.1];
     let mut previous_thrust = 0.0;
     let mut previous_torque = Vector3::zeros();
     let planner_config: Vec<PlannerStepConfig> = config
@@ -151,7 +150,6 @@ fn main() -> Result<(), SimulationError> {
                     &quad.position,
                     &quad.orientation,
                     &maze,
-                    &mut depth_buffer,
                     config.use_multithreading_depth_rendering,
                 )?;
             }
@@ -171,7 +169,7 @@ fn main() -> Result<(), SimulationError> {
                 if config.render_depth {
                     log_depth_image(
                         rec,
-                        &depth_buffer,
+                        &camera.depth_buffer,
                         camera.resolution,
                         camera.near,
                         camera.far,
@@ -182,7 +180,7 @@ fn main() -> Result<(), SimulationError> {
                         quad.position,
                         quad.orientation,
                         config.camera.rotation_transform,
-                        &depth_buffer,
+                        &camera.depth_buffer,
                     )?;
                 }
                 log_maze_obstacles(rec, &maze)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -174,7 +174,7 @@ fn main() -> Result<(), SimulationError> {
                         camera.near,
                         camera.far,
                     )?;
-                    pinhole_depth(
+                    log_pinhole_depth(
                         rec,
                         &camera,
                         quad.position,

--- a/src/main.rs
+++ b/src/main.rs
@@ -143,7 +143,7 @@ fn main() -> Result<(), SimulationError> {
         }
         imu.update(quad.time_step)?;
         let (true_accel, true_gyro) = quad.read_imu()?;
-        let (_measured_accel, _measured_gyro) = imu.read(true_accel, true_gyro)?;
+        let (measured_accel, measured_gyro) = imu.read(true_accel, true_gyro)?;
         if i % (config.simulation.simulation_frequency / config.simulation.log_frequency) == 0 {
             if config.render_depth {
                 camera.render_depth(
@@ -163,17 +163,11 @@ fn main() -> Result<(), SimulationError> {
                     &quad,
                     &desired_position,
                     &desired_velocity,
-                    &_measured_accel,
-                    &_measured_gyro,
+                    &measured_accel,
+                    &measured_gyro,
                 )?;
                 if config.render_depth {
-                    log_depth_image(
-                        rec,
-                        &camera.depth_buffer,
-                        camera.resolution,
-                        camera.near,
-                        camera.far,
-                    )?;
+                    log_depth_image(rec, &camera)?;
                     log_pinhole_depth(
                         rec,
                         &camera,

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,6 @@ fn main() -> Result<(), SimulationError> {
                         quad.position,
                         quad.orientation,
                         config.camera.rotation_transform,
-                        &camera.depth_buffer,
                     )?;
                 }
                 log_maze_obstacles(rec, &maze)?;


### PR DESCRIPTION
- Refactor depth_buffer into camera
- Optimize AABB test in ray_cast
- Rename pinhole_depth to log_pinhole_depth and Change API: use &cam instead of separate camera data
- Change API of log_depth_image: use &cam instead of separate camera data