### PR TITLE
Feature/state estimation

### DIFF
--- a/config/quad.yaml
+++ b/config/quad.yaml
@@ -34,9 +34,10 @@ pid_controller:
   att_max_int: [0.5, 0.5, 0.5] # Maximum integral error for attitude control [roll, pitch, yaw]
 
 imu:
+  add_noise_to_control: true # Feeds imu state estimation to control
   accel_noise_std: 0.02 # Standard deviation of accelerometer noise (m/s^2)
   gyro_noise_std: 0.01 # Standard deviation of gyroscope noise (rad/s)
-  accel_bias_std: 0.0001 # Standard deviation of accelerometer bias instability (m/s^2)
+q  accel_bias_std: 0.0001 # Standard deviation of accelerometer bias instability (m/s^2)
   gyro_bias_std: 0.0001 # Standard deviation of gyroscope bias instability (rad/s)
 
 maze:

--- a/config/quad.yaml
+++ b/config/quad.yaml
@@ -37,7 +37,7 @@ imu:
   add_noise_to_control: true # Feeds imu state estimation to control
   accel_noise_std: 0.02 # Standard deviation of accelerometer noise (m/s^2)
   gyro_noise_std: 0.01 # Standard deviation of gyroscope noise (rad/s)
-q  accel_bias_std: 0.0001 # Standard deviation of accelerometer bias instability (m/s^2)
+  accel_bias_std: 0.0001 # Standard deviation of accelerometer bias instability (m/s^2)
   gyro_bias_std: 0.0001 # Standard deviation of gyroscope bias instability (rad/s)
 
 maze:

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,8 @@ pub struct PIDGains {
 #[derive(serde::Deserialize, Default)]
 /// Configuration for the IMU
 pub struct ImuConfig {
+    /// Feeds imu state estimation to control
+    pub add_noise_to_control: bool,
     /// Accelerometer noise standard deviation
     pub accel_noise_std: f32,
     /// Gyroscope noise standard deviation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -388,11 +388,43 @@ impl State {
             data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
         }
     }
+
+    /// Creates a new State with provided data array
+    /// # Arguments
+    /// * `data` - An array of 13 f32 values representing the state
+    /// # Returns
+    /// * A new State instance with the provided data
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0, 7.0, 8.0, 9.0];
+    /// let state = State::new_with_data(&data);
+    /// ```
     pub fn new_with_data(data: &[f32;13]) -> Self {
         let mut state = Self::new();
         state.set_data(data);
         state
     }
+
+    /// Creates a new State with provided vectors
+    /// # Arguments
+    /// * `position` - A 3D vector representing position
+    /// * `velocity` - A 3D vector representing velocity
+    /// * `orientation` - A quaternion representing orientation
+    /// * `angular_velocity` - A 3D vector representing angular velocity
+    /// # Returns
+    /// * A new State instance with values set from the provided vectors
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::{Vector3, UnitQuaternion, Quaternion};
+    /// 
+    /// let position = Vector3::new(1.0, 2.0, 3.0);
+    /// let velocity = Vector3::new(4.0, 5.0, 6.0);
+    /// let orientation = UnitQuaternion::from_quaternion(Quaternion::new(1.0, 0.0, 0.0, 0.0));
+    /// let angular_velocity = Vector3::new(7.0, 8.0, 9.0);
+    /// let state = State::new_with_vectors(&position, &velocity, &orientation, &angular_velocity);
+    /// ```
     pub fn new_with_vectors(
         position: &Vector3<f32>,
         velocity: &Vector3<f32>,
@@ -406,20 +438,91 @@ impl State {
             angular_velocity);
         state
     }
+
+    /// Returns the position component of the state
+    /// # Returns
+    /// * A Vector3 representing the position
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::Vector3;
+    /// 
+    /// let mut state = State::new();
+    /// let position = Vector3::new(1.0, 2.0, 3.0);
+    /// state.set_position(&position);
+    /// ```
     pub fn get_position(&self) -> Vector3<f32> {
         Vector3::from_column_slice(&self.data[0..3])
     }
+
+    /// Returns the velocity component of the state
+    /// # Returns
+    /// * A Vector3 representing the velocity
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::Vector3;
+    /// 
+    /// let mut state = State::new();
+    /// let velocity = Vector3::new(4.0, 5.0, 6.0);
+    /// state.set_velocity(&velocity);
+    /// ```
     pub fn get_velocity(&self) -> Vector3<f32> {
         Vector3::from_column_slice(&self.data[3..6])
     }
+
+    /// Returns the orientation component of the state
+    /// # Returns
+    /// * A UnitQuaternion representing the orientation
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::{UnitQuaternion, Quaternion};
+    /// 
+    /// let mut state = State::new();
+    /// let orientation = UnitQuaternion::from_quaternion(Quaternion::new(0.7071, 0.0, 0.7071, 0.0));
+    /// state.set_orientation(&orientation);
+    /// ```
     pub fn get_orientation(&self) -> UnitQuaternion<f32> {
         UnitQuaternion::from_quaternion(Quaternion::new(
             self.data[9], self.data[6], self.data[7], self.data[8],
         ))
     }
+
+    /// Returns the angular velocity component of the state
+    /// # Returns
+    /// * A Vector3 representing the angular velocity
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::Vector3;
+    /// 
+    /// let mut state = State::new();
+    /// let angular_velocity = Vector3::new(7.0, 8.0, 9.0);
+    /// state.set_angular_velocity(&angular_velocity);
+    /// ```
     pub fn get_angular_velocity(&self) -> Vector3<f32> {
         Vector3::from_column_slice(&self.data[10..13])
     }
+
+    /// Returns all components of the state as vectors
+    /// # Returns
+    /// * A tuple containing position, velocity, orientation, and angular velocity
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::{Vector3, UnitQuaternion, Quaternion};
+    /// 
+    /// let position = Vector3::new(1.0, 2.0, 3.0);
+    /// let velocity = Vector3::new(4.0, 5.0, 6.0);
+    /// let orientation = UnitQuaternion::from_quaternion(Quaternion::new(1.0, 0.0, 0.0, 0.0));
+    /// let angular_velocity = Vector3::new(7.0, 8.0, 9.0);
+    /// 
+    /// let mut state = State::new();
+    /// state.set_with_vectors(&position, &velocity, &orientation, &angular_velocity);
+    /// 
+    /// let (pos, vel, orient, ang_vel) = state.get_state_vectors();
+    /// ```
     pub fn get_state_vectors(&self) -> (Vector3<f32>, Vector3<f32>, UnitQuaternion<f32>, Vector3<f32>) {
         (
             self.get_position(),
@@ -428,25 +531,121 @@ impl State {
             self.get_angular_velocity(),
         )
     }
+
+    /// Returns the raw data array of the state
+    /// # Returns
+    /// * An array of 13 f32 values representing the complete state
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// 
+    /// let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0, 7.0, 8.0, 9.0];
+    /// let state = State::new_with_data(&data);
+    /// ```
     pub fn get_state_data(&self) -> [f32; 13] {
             self.data.clone()
     }
+
+    /// Sets the position component of the state
+    /// # Arguments
+    /// * `position` - A Vector3 representing the new position
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::Vector3;
+    /// 
+    /// let mut state = State::new();
+    /// let position = Vector3::new(1.0, 2.0, 3.0);
+    /// state.set_position(&position);
+    /// ```
     pub fn set_position(&mut self, position: &Vector3<f32>) {
         self.data[0..3].copy_from_slice(position.as_slice());
     }
+
+    /// Sets the velocity component of the state
+    /// # Arguments
+    /// * `velocity` - A Vector3 representing the new velocity
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::Vector3;
+    /// 
+    /// let mut state = State::new();
+    /// let velocity = Vector3::new(4.0, 5.0, 6.0);
+    /// state.set_velocity(&velocity);
+    /// 
+    /// assert_eq!(state.get_velocity(), velocity);
+    /// ```
     pub fn set_velocity(&mut self, velocity: &Vector3<f32>) {
         self.data[3..6].copy_from_slice(velocity.as_slice());
-
     }
+
+    /// Sets the orientation component of the state
+    /// # Arguments
+    /// * `orientation` - A UnitQuaternion representing the new orientation
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::{UnitQuaternion, Quaternion};
+    /// 
+    /// let mut state = State::new();
+    /// let orientation = UnitQuaternion::from_quaternion(Quaternion::new(0.0, 1.0, 0.0, 0.0));
+    /// state.set_orientation(&orientation);
+    /// ```
     pub fn set_orientation(&mut self, orientation: &UnitQuaternion<f32>) {
         self.data[6..10].copy_from_slice(orientation.coords.as_slice());
     }
+
+    /// Sets the angular velocity component of the state
+    /// # Arguments
+    /// * `angular_velocity` - A Vector3 representing the new angular velocity
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::Vector3;
+    /// 
+    /// let mut state = State::new();
+    /// let angular_velocity = Vector3::new(7.0, 8.0, 9.0);
+    /// state.set_angular_velocity(&angular_velocity);
+    /// ```
     pub fn set_angular_velocity(&mut self, angular_velocity: &Vector3<f32>) {
         self.data[10..13].copy_from_slice(angular_velocity.as_slice());
     }
+
+    /// Sets all raw data values at once
+    /// # Arguments
+    /// * `data` - An array of 13 f32 values representing the complete state
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// 
+    /// let mut state = State::new();
+    /// let data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0, 7.0, 8.0, 9.0];
+    /// state.set_data(&data);
+    /// ```
     pub fn set_data(&mut self, data: &[f32;13]) {
         self.data = *data
     }
+
+    /// Sets all components of the state using vectors
+    /// # Arguments
+    /// * `position` - A Vector3 representing the new position
+    /// * `velocity` - A Vector3 representing the new velocity
+    /// * `orientation` - A UnitQuaternion representing the new orientation
+    /// * `angular_velocity` - A Vector3 representing the new angular velocity
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// use nalgebra::{Vector3, UnitQuaternion, Quaternion};
+    /// 
+    /// let mut state = State::new();
+    /// let position = Vector3::new(1.0, 2.0, 3.0);
+    /// let velocity = Vector3::new(4.0, 5.0, 6.0);
+    /// let orientation = UnitQuaternion::from_quaternion(Quaternion::new(1.0, 0.0, 0.0, 0.0));
+    /// let angular_velocity = Vector3::new(7.0, 8.0, 9.0);
+    /// 
+    /// state.set_with_vectors(&position, &velocity, &orientation, &angular_velocity);
+    /// ```
     pub fn set_with_vectors(&mut self,
         position: &Vector3<f32>,
         velocity: &Vector3<f32>,
@@ -457,7 +656,6 @@ impl State {
         self.set_orientation(orientation);
         self.set_angular_velocity(angular_velocity);
     }
-   
 }
 /// Represents an Inertial Measurement Unit (IMU) with bias and noise characteristics
 /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,6 +369,96 @@ impl Quadrotor {
         Ok((self.acceleration, self.angular_velocity))
     }
 }
+#[derive(Clone)]
+pub struct State {
+    data: [f32; 13]
+}
+impl State {
+    /// Creates a new State with default values
+    /// # Returns
+    /// * A new State instance
+    /// # Example
+    /// ```
+    /// use peng_quad::State;
+    /// let state = State::new();
+    /// ```
+    
+    pub fn new() -> Self {
+        Self {
+            data: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        }
+    }
+    pub fn new_with_data(data: &[f32;13]) -> Self {
+        let mut state = Self::new();
+        state.set_data(data);
+        state
+    }
+    pub fn new_with_vectors(
+        position: &Vector3<f32>,
+        velocity: &Vector3<f32>,
+        orientation: &UnitQuaternion<f32>,
+        angular_velocity: &Vector3<f32>) -> Self {
+        let mut state = Self::new();
+        state.set_with_vectors(
+            position,
+            velocity,
+            orientation,
+            angular_velocity);
+        state
+    }
+    pub fn get_position(&self) -> Vector3<f32> {
+        Vector3::from_column_slice(&self.data[0..3])
+    }
+    pub fn get_velocity(&self) -> Vector3<f32> {
+        Vector3::from_column_slice(&self.data[3..6])
+    }
+    pub fn get_orientation(&self) -> UnitQuaternion<f32> {
+        UnitQuaternion::from_quaternion(Quaternion::new(
+            self.data[9], self.data[6], self.data[7], self.data[8],
+        ))
+    }
+    pub fn get_angular_velocity(&self) -> Vector3<f32> {
+        Vector3::from_column_slice(&self.data[10..13])
+    }
+    pub fn get_state_vectors(&self) -> (Vector3<f32>, Vector3<f32>, UnitQuaternion<f32>, Vector3<f32>) {
+        (
+            self.get_position(),
+            self.get_velocity(),
+            self.get_orientation(),
+            self.get_angular_velocity(),
+        )
+    }
+    pub fn get_state_data(&self) -> [f32; 13] {
+            self.data.clone()
+    }
+    pub fn set_position(&mut self, position: &Vector3<f32>) {
+        self.data[0..3].copy_from_slice(position.as_slice());
+    }
+    pub fn set_velocity(&mut self, velocity: &Vector3<f32>) {
+        self.data[3..6].copy_from_slice(velocity.as_slice());
+
+    }
+    pub fn set_orientation(&mut self, orientation: &UnitQuaternion<f32>) {
+        self.data[6..10].copy_from_slice(orientation.coords.as_slice());
+    }
+    pub fn set_angular_velocity(&mut self, angular_velocity: &Vector3<f32>) {
+        self.data[10..13].copy_from_slice(angular_velocity.as_slice());
+    }
+    pub fn set_data(&mut self, data: &[f32;13]) {
+        self.data = *data
+    }
+    pub fn set_with_vectors(&mut self,
+        position: &Vector3<f32>,
+        velocity: &Vector3<f32>,
+        orientation: &UnitQuaternion<f32>,
+        angular_velocity: &Vector3<f32>) {
+        self.set_position(position);
+        self.set_velocity(velocity);
+        self.set_orientation(orientation);
+        self.set_angular_velocity(angular_velocity);
+    }
+   
+}
 /// Represents an Inertial Measurement Unit (IMU) with bias and noise characteristics
 /// # Example
 /// ```


### PR DESCRIPTION
This branch encorporates 2 primary changes include the addition of a new `State` struct to encapsulate the quadrotor's state and modifications to the main simulation loop to utilize this new state structure. Additionally, a configuration option to add noise to the IMU control has been added.

### State Management Improvements:
* Added a new `State` struct in `src/lib.rs` with methods to create, modify, and retrieve state components such as position, velocity, orientation, and angular velocity. **Please provide feedback on whether this implementation needs to be modified.**
* Updated the main simulation loop in `src/main.rs` to use the new `State` struct for managing the quadrotor's state. This includes initializing the state and updating it based on IMU readings and control inputs. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR105-R112) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL118-R143) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR162-R177) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR213)

### Configuration Enhancements:
* Added a new configuration option `add_noise_to_control` in `config/quad.yaml` and `src/config.rs` to control whether IMU noise is added to the state estimation for control purposes. [[1]](diffhunk://#diff-e88e288241a6d1ce3c0545b2a6c40a31ed94a2046220926020fc3c04e0c1e285R37) [[2]](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdR105-R106)

### Codebase Adjustments:
* Updated imports in `src/main.rs` to include `UnitQuaternion` from the `nalgebra` crate, which is used in the new `State` struct methods.

These changes enhance the simulation's accuracy and flexibility by providing a more structured approach to state management and allowing for configurable noise in the control logic.